### PR TITLE
debug incomplete answers

### DIFF
--- a/MPD/MPDConnection.php
+++ b/MPD/MPDConnection.php
@@ -173,9 +173,11 @@ class MPDConnection
      */
     private function receiveAnswer(): ?array
     {
+        $result = array();
         while ($this->isConnected()) {
-            $answer = socket_read($this->socket, 1024);
-            $result = explode("\n", trim($answer));
+            $answer = socket_read($this->socket, 4096, PHP_NORMAL_READ);
+            $tmpResult = explode("\n", trim($answer));
+            $result = array_merge($result,$tmpResult);
             if ($this->checkIfAnswerGotten(end($result))) {
                 return $result;
             }


### PR DESCRIPTION
The receiveAnswer() function was overwriting the answers recieved in the same array.
Also, I added the PHP_NORMAL_READ to stop read at each end of line otherwise a line could be trucated and splitted in to two rows